### PR TITLE
Strengthen project search scope test

### DIFF
--- a/apps/client/src/search-utils.test.ts
+++ b/apps/client/src/search-utils.test.ts
@@ -128,9 +128,10 @@ describe("performSearch", () => {
       sessions,
       chatData,
     });
-    // "fix the model" and "updated the model" are in s2 (same project)
-    // "Hi there!" is in s1 (same project)
+
     const sessionIds = new Set(results.map((r) => r.sessionId));
+    expect(results).toHaveLength(3);
+    expect(sessionIds).toEqual(new Set(["s1", "s2"]));
     expect(sessionIds.has("s3")).toBe(false); // other project excluded
   });
 


### PR DESCRIPTION
Tightens the project-scoped search test so it asserts both expected same-project sessions and the exact result count.

Validation:
- vp test apps/client/src/search-utils.test.ts
- vp test

Note: vp check currently reports formatting issues in unrelated existing files; this PR does not touch those files.