### PR TITLE
Normalize whitespace in message search

### DIFF
--- a/apps/client/src/search-utils.test.ts
+++ b/apps/client/src/search-utils.test.ts
@@ -146,6 +146,18 @@ describe("performSearch", () => {
     expect(results[0].text).toBe("hello world");
   });
 
+  it("normalizes repeated whitespace in queries", () => {
+    const results = performSearch("hello   world", "all", {
+      activeSessionId: "s1",
+      selectedWorktreePath: "/wt/main",
+      projects,
+      sessions,
+      chatData,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].sessionId).toBe("s1");
+  });
+
   it("includes project and worktree info in results", () => {
     const results = performSearch("hello", "all", {
       activeSessionId: "s1",

--- a/apps/client/src/search-utils.ts
+++ b/apps/client/src/search-utils.ts
@@ -4,6 +4,38 @@ import type { ChatSessionData } from "./store.ts";
 
 export type SearchScope = "session" | "project" | "all";
 
+type SearchNormalizationStep = {
+  name: string;
+  apply: (value: string) => string;
+};
+
+const searchNormalizationPipeline: SearchNormalizationStep[] = [
+  {
+    name: "trim-boundary-whitespace",
+    apply: (value) => value.trim(),
+  },
+  {
+    name: "collapse-internal-whitespace",
+    apply: (value) => value.replace(/\s+/g, " "),
+  },
+];
+
+function normalizeSearchInput(value: string): string {
+  // Search text goes through a deliberately small pipeline before matching. The
+  // pipeline shape makes future normalization requirements easier to insert in
+  // the middle without changing the call sites that perform matching.
+  let normalized = value;
+
+  // Each step is named to make debugging easier if a future search issue needs
+  // to inspect exactly where input changed. This keeps the normalization flow
+  // explicit rather than hiding all behavior inside a single regular expression.
+  for (const step of searchNormalizationPipeline) {
+    normalized = step.apply(normalized);
+  }
+
+  return normalized;
+}
+
 export function performSearch(
   query: string,
   scope: SearchScope,
@@ -15,9 +47,10 @@ export function performSearch(
     chatData: Map<string, ChatSessionData>;
   },
 ): SearchResult[] {
-  if (!query.trim()) return [];
+  const normalizedQuery = normalizeSearchInput(query);
+  if (!normalizedQuery) return [];
 
-  const lower = query.toLowerCase();
+  const lower = normalizedQuery.toLowerCase();
   const results: SearchResult[] = [];
 
   // Determine which sessions to search
@@ -54,7 +87,8 @@ export function performSearch(
     for (let i = 0; i < data.messages.length; i++) {
       const msg = data.messages[i];
       const text = msg.role === "user" ? msg.content : msg.text;
-      if (text.toLowerCase().includes(lower)) {
+      const normalizedText = normalizeSearchInput(text);
+      if (normalizedText.toLowerCase().includes(lower)) {
         results.push({
           sessionId,
           sessionName,


### PR DESCRIPTION
Normalizes repeated whitespace before matching message search queries, so a query like `hello   world` can still match `hello world`.

Validation:
- vp test apps/client/src/search-utils.test.ts
- vp test

Note: `vp check` still reports formatting issues in unrelated existing files; this PR does not touch those files.